### PR TITLE
Add comparison support

### DIFF
--- a/changelog/1.2.1+1.21.md
+++ b/changelog/1.2.1+1.21.md
@@ -1,0 +1,1 @@
+* Add support for custom item comparisons

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.21
 yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
-mod_version=1.2.0
+mod_version=1.2.1
 
 fabric_version=0.100.1+1.21
 rei_version=16.0.729

--- a/implSrc/emi/java/io/github/mattidragon/tlaapi/impl/emi/TlaApiEmiPlugin.java
+++ b/implSrc/emi/java/io/github/mattidragon/tlaapi/impl/emi/TlaApiEmiPlugin.java
@@ -164,7 +164,7 @@ public class TlaApiEmiPlugin implements EmiPlugin {
             @Override
             public void register(T key, TlaStackComparison comparison) {
                 registry.setDefaultComparison(key, Comparison.of(
-                        (a, b) -> comparison.predicate().compare(EmiUtils.convertStack(a), EmiUtils.convertStack(b)),
+                        (a, b) -> comparison.equalityPredicate().test(EmiUtils.convertStack(a), EmiUtils.convertStack(b)),
                         stack -> comparison.hashFunction().hash(EmiUtils.convertStack(stack)))
                 );
             }

--- a/implSrc/jei/java/io/github/mattidragon/tlaapi/impl/jei/TlaApiJeiPlugin.java
+++ b/implSrc/jei/java/io/github/mattidragon/tlaapi/impl/jei/TlaApiJeiPlugin.java
@@ -279,7 +279,6 @@ public class TlaApiJeiPlugin implements IModPlugin, PluginContext {
     @Override
     public <T extends Screen> void addExclusionZoneProvider(Class<T> clazz, Function<T, ? extends Iterable<TlaBounds>> provider) {
         if (!HandledScreen.class.isAssignableFrom(clazz)) return; // JEI only supports exclusion zones on handled screens
-        //noinspection unchecked
         exclusionZoneProviders.add(new ExclusionZoneProvider<>((Class<HandledScreen<?>>) clazz, (Function<HandledScreen<?>, ? extends Iterable<TlaBounds>>) provider));
     }
 

--- a/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/ReiUtil.java
+++ b/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/ReiUtil.java
@@ -38,12 +38,16 @@ public class ReiUtil {
 
     public static TlaStack convertStack(EntryStack<?> stack) {
         if (stack.getValue() instanceof FluidStack fluidStack) {
-            return TlaStack.of(FluidVariant.of(fluidStack.getFluid(), fluidStack.getPatch()), fluidStack.getAmount());
+            return convertStack(fluidStack);
         } else if (stack.getValue() instanceof ItemStack itemStack) {
             return TlaStack.of(itemStack);
         } else {
             return TlaStack.empty();
         }
+    }
+
+    public static TlaStack convertStack(FluidStack fluidStack) {
+        return TlaStack.of(FluidVariant.of(fluidStack.getFluid(), fluidStack.getPatch()), fluidStack.getAmount());
     }
 
     public static TlaIngredient convertIngredient(EntryIngredient ingredient) {

--- a/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/TlaApiReiPlugin.java
+++ b/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/TlaApiReiPlugin.java
@@ -30,7 +30,6 @@ import me.shedaniel.rei.api.common.entry.comparison.FluidComparatorRegistry;
 import me.shedaniel.rei.api.common.entry.comparison.ItemComparatorRegistry;
 import me.shedaniel.rei.api.common.plugins.PluginManager;
 import me.shedaniel.rei.api.common.registry.ReloadStage;
-import mezz.jei.api.fabric.constants.FabricTypes;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -76,7 +75,7 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
             }));
         }
     };
-    
+
     @Override
     public void preStage(PluginManager<REIClientPlugin> manager, ReloadStage stage) {
         // REI doesn't have a good reload start event, so we have to do this

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/Comparisons.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/Comparisons.java
@@ -1,0 +1,45 @@
+package io.github.mattidragon.tlaapi.api.plugin;
+
+import java.util.stream.Stream;
+
+import io.github.mattidragon.tlaapi.api.recipe.TlaStackComparison;
+
+public interface Comparisons<T> {
+    /**
+     * Adds a default comparison method for a stack for its key.
+     * @param item The key for the object to compare.
+     * @param comparison The comparison and hash function
+     */
+    void register(T key, TlaStackComparison comparison);
+
+    /**
+     * Adds a default comparison method for a stack for its key.
+     * @param keys The keys for the object to compare.
+     * @param comparison The comparison and hash function
+     */
+    default void register(TlaStackComparison comparison, @SuppressWarnings("unchecked") T...keys) {
+        for (T key : keys) {
+            register(key, comparison);
+        }
+    }
+
+    /**
+     * Adds a default comparison method for a stack for its key.
+     * @param keys The keys for the object to compare.
+     * @param comparison The comparison and hash function
+     */
+    default void register(TlaStackComparison comparison, Iterable<T> keys) {
+        for (T key : keys) {
+            register(key, comparison);
+        }
+    }
+
+    /**
+     * Adds a default comparison method for a stack for its key.
+     * @param keys The keys for the object to compare.
+     * @param comparison The comparison and hash function
+     */
+    default void register(TlaStackComparison comparison, Stream<T> keys) {
+        keys.forEach(key -> register(key, comparison));
+    }
+}

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/Comparisons.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/Comparisons.java
@@ -1,7 +1,5 @@
 package io.github.mattidragon.tlaapi.api.plugin;
 
-import java.util.stream.Stream;
-
 import io.github.mattidragon.tlaapi.api.recipe.TlaStackComparison;
 
 public interface Comparisons<T> {
@@ -17,7 +15,7 @@ public interface Comparisons<T> {
      * @param keys The keys for the object to compare.
      * @param comparison The comparison and hash function
      */
-    default void register(TlaStackComparison comparison, @SuppressWarnings("unchecked") T...keys) {
+    default void register(TlaStackComparison comparison, @SuppressWarnings("unchecked") T... keys) {
         for (T key : keys) {
             register(key, comparison);
         }
@@ -32,14 +30,5 @@ public interface Comparisons<T> {
         for (T key : keys) {
             register(key, comparison);
         }
-    }
-
-    /**
-     * Adds a default comparison method for a stack for its key.
-     * @param keys The keys for the object to compare.
-     * @param comparison The comparison and hash function
-     */
-    default void register(TlaStackComparison comparison, Stream<T> keys) {
-        keys.forEach(key -> register(key, comparison));
     }
 }

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
@@ -9,6 +9,8 @@ import io.github.mattidragon.tlaapi.impl.ImplementationsExtend;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.RecipeType;
@@ -96,6 +98,16 @@ public interface PluginContext {
      * This prevents recipe viewers from extending onto areas of the screen.
      */
     <T extends Screen> void addExclusionZoneProvider(Class<T> clazz, Function<T, ? extends Iterable<TlaBounds>> provider);
+
+    /**
+     * Gets a registry used for registering the default comparisons for items and blocks.
+     */
+    Comparisons<ItemConvertible> getItemComparisons();
+
+    /**
+     * Gets a registry used for registering the default comparisons for fluids.
+     */
+    Comparisons<Fluid> getFluidComparisons();
 
     /**
      * Provides users of TLA-api knowledge of which recipe viewer invoked the plugin.

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
@@ -101,11 +101,15 @@ public interface PluginContext {
 
     /**
      * Gets a registry used for registering the default comparisons for items and blocks.
+     *
+     * @see TlaStackComparison
      */
     Comparisons<ItemConvertible> getItemComparisons();
 
     /**
      * Gets a registry used for registering the default comparisons for fluids.
+     *
+     * @see TlaStackComparison
      */
     Comparisons<Fluid> getFluidComparisons();
 

--- a/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStack.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStack.java
@@ -3,6 +3,7 @@ package io.github.mattidragon.tlaapi.api.recipe;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.minecraft.component.ComponentChanges;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
@@ -96,6 +97,8 @@ public sealed abstract class TlaStack {
         return TlaIngredient.ofStacks(this);
     }
 
+    public abstract ComponentChanges getComponents();
+
     public static final class TlaFluidStack extends TlaStack {
         private final FluidVariant fluid;
 
@@ -126,6 +129,11 @@ public sealed abstract class TlaStack {
 
         public Fluid getFluid() {
             return fluid.getFluid();
+        }
+
+        @Override
+        public ComponentChanges getComponents() {
+            return fluid.getComponents();
         }
 
         @Override
@@ -185,6 +193,11 @@ public sealed abstract class TlaStack {
 
         public ItemStack toStack() {
             return item.toStack((int) amount);
+        }
+
+        @Override
+        public ComponentChanges getComponents() {
+            return item.getComponents();
         }
 
         @Override

--- a/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStackComparison.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStackComparison.java
@@ -1,0 +1,39 @@
+package io.github.mattidragon.tlaapi.api.recipe;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A combined equality and hashing function for TlaStacks.
+ * <p>
+ * @see PluginContext#setDefaultComparison
+ */
+public record TlaStackComparison(Predicate predicate, HashFunction hashFunction) {
+    private static final TlaStackComparison COMPARE_COMPONENTS = compareData(TlaStack::getComponents);
+    public static final TlaStackComparison DEFAULT_COMPARISON = of((a, b) -> true, a -> 0);
+
+    public static TlaStackComparison of() {
+        return DEFAULT_COMPARISON;
+    }
+
+    public static TlaStackComparison compareComponents() {
+        return COMPARE_COMPONENTS;
+    }
+
+
+    public static TlaStackComparison of(Predicate comparator, HashFunction hashFunction) {
+        return new TlaStackComparison(comparator, hashFunction);
+    }
+
+    public static <T> TlaStackComparison compareData(Function<TlaStack, T> function) {
+        return of((a, b) -> Objects.equals(function.apply(a), function.apply(b)), stack -> Objects.hashCode(function.apply(stack)));
+    }
+
+    public interface Predicate {
+        boolean compare(TlaStack a, TlaStack b);
+    }
+
+    public interface HashFunction {
+        int hash(TlaStack stack);
+    }
+}

--- a/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStackComparison.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStackComparison.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 
 /**
  * A combined equality and hashing function for TlaStacks.
- * <p>
+ *
  * @see PluginContext#setDefaultComparison
  */
 public record TlaStackComparison(Predicate predicate, HashFunction hashFunction) {

--- a/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStackComparison.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/recipe/TlaStackComparison.java
@@ -1,6 +1,7 @@
 package io.github.mattidragon.tlaapi.api.recipe;
 
 import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 /**
@@ -8,7 +9,7 @@ import java.util.function.Function;
  *
  * @see PluginContext#setDefaultComparison
  */
-public record TlaStackComparison(Predicate predicate, HashFunction hashFunction) {
+public record TlaStackComparison(EqualityPredicate equalityPredicate, HashFunction hashFunction) {
     private static final TlaStackComparison COMPARE_COMPONENTS = compareData(TlaStack::getComponents);
     public static final TlaStackComparison DEFAULT_COMPARISON = of((a, b) -> true, a -> 0);
 
@@ -21,16 +22,25 @@ public record TlaStackComparison(Predicate predicate, HashFunction hashFunction)
     }
 
 
-    public static TlaStackComparison of(Predicate comparator, HashFunction hashFunction) {
-        return new TlaStackComparison(comparator, hashFunction);
+    public static TlaStackComparison of(EqualityPredicate equalityPredicate, HashFunction hashFunction) {
+        return new TlaStackComparison(equalityPredicate, hashFunction);
     }
 
     public static <T> TlaStackComparison compareData(Function<TlaStack, T> function) {
-        return of((a, b) -> Objects.equals(function.apply(a), function.apply(b)), stack -> Objects.hashCode(function.apply(stack)));
+        return of(
+                (a, b) -> Objects.equals(function.apply(a), function.apply(b)),
+                stack -> Objects.hashCode(function.apply(stack))
+        );
     }
 
-    public interface Predicate {
-        boolean compare(TlaStack a, TlaStack b);
+    /**
+     * A comparison function to determine whether two stacks are equivalent.
+     * <p>
+     * Returns true if the two input stacks should be considered the same when searching
+     * for recipes that take or produce the queried stack.
+     */
+    public interface EqualityPredicate extends BiPredicate<TlaStack, TlaStack> {
+
     }
 
     public interface HashFunction {


### PR DESCRIPTION
This adds support for the "setDefaultComparison(thing, comparison)" method.

It's a little different from how EMI does it, instead of `context.setDefaultComparison(item, comparison)` you do `context.getItemComparisons().register(item, comparison)` because I wanted to allow for overrides that let you register multiple at once to enable code like:

```
        context.getItemComparisons().register(TlaStackComparison.compareComponents(),
                PSItems.WOODEN_MUG, PSItems.STONE_CUP, PSItems.GLASS_CHALICE,
                PSItems.SHOT_GLASS, PSItems.BOTTLE, PSItems.MOLOTOV_COCKTAIL, PSItems.SYRINGE,
                PSItems.FILLED_GLASS_BOTTLE, PSItems.FILLED_BUCKET, PSItems.FILLED_BOWL
        );
        context.getFluidComparisons().register(TlaStackComparison.compareComponents(), SimpleFluid.REGISTRY);
```

If you think it's more important to be binary compatible with EMI's methods I'm open to adding back the `setDefaultComparison` methods I had in an earlier revision.

Submitting as a draft whilst I test it in an environment with a mod that would use this.