### PR TITLE
1.21 update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,12 +99,13 @@ dependencies {
     modImplementation(libs.fabric.loader)
     modImplementation(libs.fabric.api)
 
-    add("modReiCompileOnly", libs.rei.api)
+    // add("modReiCompileOnly", libs.rei.api)
     add("modReiCompileOnly", libs.rei.plugin.default)
     // For some reason arch isn't a transitive dependency of rei-api, so we need to manually add it to use a few classes
     add("modReiCompileOnly", libs.rei.architectury)
     add("modReiCompileOnly", libs.rei.config)
-    add("modReiRuntimeOnly", libs.rei.all)
+    // Because of issues with the rei api, we have to depend on the fat jar instead (https://github.com/shedaniel/RoughlyEnoughItems/issues/1740)
+    add("modReiCompileOnly", libs.rei.all)
 
     add("modEmiCompileOnly", libs.emi.withClassifier("api"))
     add("modEmiRuntimeOnly", libs.emi)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ mod_version=1.2.0
 
 fabric_version=0.102.0+1.21
 rei_version=16.0.783
-architectury_version=13.0.1
+architectury_version=13.0.6
 emi_version=1.1.12+1.21
-cloth_config_version=15.0.127
+cloth_config_version=15.0.130
 jei_version=19.8.2.99

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
 minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+yarn_mappings=1.21+build.9
+loader_version=0.16.5
 
 mod_version=1.2.0
 
-fabric_version=0.100.1+1.21
-rei_version=16.0.729
+fabric_version=0.102.0+1.21
+rei_version=16.0.783
 architectury_version=13.0.1
-emi_version=1.1.7+1.21
+emi_version=1.1.12+1.21
 cloth_config_version=15.0.127
-jei_version=19.0.0.9
+jei_version=19.8.2.99

--- a/implSrc/jei/java/io/github/mattidragon/tlaapi/impl/jei/TlaApiJeiPlugin.java
+++ b/implSrc/jei/java/io/github/mattidragon/tlaapi/impl/jei/TlaApiJeiPlugin.java
@@ -118,37 +118,37 @@ public class TlaApiJeiPlugin implements IModPlugin, PluginContext {
                     var bounds = provider.provider.apply(screen);
                     return new IGuiProperties() {
                         @Override
-                        public Class<? extends Screen> getScreenClass() {
+                        public Class<? extends Screen> screenClass() {
                             return provider.clazz;
                         }
 
                         @Override
-                        public int getGuiLeft() {
+                        public int guiLeft() {
                             return bounds.left();
                         }
 
                         @Override
-                        public int getGuiTop() {
+                        public int guiTop() {
                             return bounds.top();
                         }
 
                         @Override
-                        public int getGuiXSize() {
+                        public int guiXSize() {
                             return bounds.width();
                         }
 
                         @Override
-                        public int getGuiYSize() {
+                        public int guiYSize() {
                             return bounds.height();
                         }
 
                         @Override
-                        public int getScreenWidth() {
+                        public int screenWidth() {
                             return screen.width;
                         }
 
                         @Override
-                        public int getScreenHeight() {
+                        public int screenHeight() {
                             return screen.height;
                         }
                     };


### PR DESCRIPTION
This moves everything from:

yarn: `1.21+build.2` -> `1.21+build.9`
fabric-loader: `0.15.11` -> `0.16.5`
fabric-api: `0.100.1+1.21` -> `0.102.0+1.21`

rei: `16.0.729` -> `16.0.783` (with workaround for https://github.com/shedaniel/RoughlyEnoughItems/issues/1740 )
emi: `1.1.7+1.21` -> `1.1.12+1.21`
jei: `19.0.0.9` -> `19.8.2.99`
