### PR TITLE
Fix error rendering recipes that use custom widgets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,10 @@ arrayOf("rei", "emi", "jei").forEach { name ->
         from(sourceSet.output)
         dependsOn(sourceSet.classesTaskName)
     }
+
+    tasks.remapJar {
+        classpath.from(configurations.getByName(sourceSet.compileClasspathConfigurationName))
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This adds the other sources' classpaths to the one use for remapping. Without it loom doesn't properly remap Tla and the result is that even though everything works in dev, some things break in hard-to-trace ways when using the mod in production.

An example is if a recipe uses `GuiBuilder.addCustomWidget`, you'll get a failure to render with the following printed in the logs:

```
[11:52:46] [Render thread/INFO]: [STDERR]: 	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
[11:52:46] [Render thread/INFO]: [STDERR]: 	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
[11:52:46] [Render thread/INFO]: [STDERR]: 	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:100)
[11:52:46] [Render thread/INFO]: [STDERR]: 	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
[11:52:46] [Render thread/INFO]: [STDERR]: 	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
[11:52:56] [Render thread/INFO]: [STDERR]: java.lang.AbstractMethodError: Receiver class io.github.mattidragon.tlaapi.impl.emi.EmiCustomWidget does not define or inherit an implementation of the resolved method 'abstract void method_25394(net.minecraft.class_332, int, int, float)' of abstract class dev.emi.emi.api.widget.Widget.
```