### PR TITLE
Add support for getting a reference to vanilla categories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ val fabricVersion = property("fabric_version") as String
 
 version = property("mod_version") as String
 group = "io.github.mattidragon"
-base.archivesName = "TLA-Api"
 
 repositories {
     maven("https://maven.shedaniel.me/")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.21
 yarn_mappings=1.21+build.9
 loader_version=0.16.5
 
-mod_version=1.2.2-beta.1
+mod_version=1.2.2-beta.2
 
 fabric_version=0.102.0+1.21
 rei_version=16.0.783

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.21
 yarn_mappings=1.21+build.9
 loader_version=0.16.5
 
-mod_version=1.2.1
+mod_version=1.2.2-beta.1
 
 fabric_version=0.102.0+1.21
 rei_version=16.0.783

--- a/implSrc/emi/java/io/github/mattidragon/tlaapi/impl/emi/TlaApiEmiPlugin.java
+++ b/implSrc/emi/java/io/github/mattidragon/tlaapi/impl/emi/TlaApiEmiPlugin.java
@@ -88,7 +88,7 @@ public class TlaApiEmiPlugin implements EmiPlugin {
                 case FUEL -> VanillaEmiRecipeCategories.FUEL;
                 case COMPOSTING -> VanillaEmiRecipeCategories.COMPOSTING;
                 case INFO -> VanillaEmiRecipeCategories.INFO;
-            }).map(category -> builtInCategories.computeIfAbsent(category, BuiltInCategory::new));
+            }).map(category -> builtInCategories.computeIfAbsent(category, id -> new BuiltInCategory(id, type.getSize())));
         }
 
         @Override
@@ -211,7 +211,7 @@ public class TlaApiEmiPlugin implements EmiPlugin {
         }
     }
 
-    private record BuiltInCategory(EmiRecipeCategory category) implements TlaCategory {
+    private record BuiltInCategory(EmiRecipeCategory category, int[] size) implements TlaCategory {
         private static final CategoryIcon ICON = CategoryIcon.stack(TlaStack.empty());
 
         @Override
@@ -221,12 +221,12 @@ public class TlaApiEmiPlugin implements EmiPlugin {
 
         @Override
         public int getDisplayHeight() {
-            return 0;
+            return size[1];
         }
 
         @Override
         public int getDisplayWidth() {
-            return 0;
+            return size[0];
         }
 
         @Override

--- a/implSrc/emi/java/io/github/mattidragon/tlaapi/impl/emi/TlaApiEmiPlugin.java
+++ b/implSrc/emi/java/io/github/mattidragon/tlaapi/impl/emi/TlaApiEmiPlugin.java
@@ -5,18 +5,22 @@ import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.stack.Comparison;
+import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.widget.Bounds;
 import io.github.mattidragon.tlaapi.api.StackDragHandler;
+import io.github.mattidragon.tlaapi.api.BuiltInRecipeCategory;
 import io.github.mattidragon.tlaapi.api.gui.TlaBounds;
 import io.github.mattidragon.tlaapi.api.plugin.Comparisons;
 import io.github.mattidragon.tlaapi.api.plugin.PluginContext;
 import io.github.mattidragon.tlaapi.api.plugin.PluginLoader;
 import io.github.mattidragon.tlaapi.api.plugin.RecipeViewer;
+import io.github.mattidragon.tlaapi.api.recipe.CategoryIcon;
 import io.github.mattidragon.tlaapi.api.recipe.TlaCategory;
 import io.github.mattidragon.tlaapi.api.recipe.TlaIngredient;
 import io.github.mattidragon.tlaapi.api.recipe.TlaRecipe;
 import io.github.mattidragon.tlaapi.api.recipe.TlaStackComparison;
+import io.github.mattidragon.tlaapi.api.recipe.TlaStack;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
@@ -27,10 +31,13 @@ import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.recipe.input.RecipeInput;
+import net.minecraft.util.Identifier;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 public class TlaApiEmiPlugin implements EmiPlugin {
@@ -41,6 +48,7 @@ public class TlaApiEmiPlugin implements EmiPlugin {
 
     private static final class EmiImplementation implements PluginContext {
         private final EmiRegistry registry;
+        private final Map<EmiRecipeCategory, TlaCategory> builtInCategories = new HashMap<>();
         private final Map<TlaCategory, EmiRecipeCategory> categories = new HashMap<>();
 
         private final Comparisons<ItemConvertible> itemComparisons = new EmiComparisons<>();
@@ -52,18 +60,50 @@ public class TlaApiEmiPlugin implements EmiPlugin {
 
         @Override
         public void addCategory(TlaCategory category) {
+            if (builtInCategories.containsValue(category)) {
+                return;
+            }
             var emiCategory = new TlaEmiRecipeCategory(category);
             categories.put(category, emiCategory);
             registry.addCategory(emiCategory);
         }
 
         @Override
+        public Optional<TlaCategory> getVanillaCategory(BuiltInRecipeCategory type) {
+            return Optional.ofNullable(switch (type) {
+                case CRAFTING -> VanillaEmiRecipeCategories.CRAFTING;
+                case SMELTING -> VanillaEmiRecipeCategories.SMELTING;
+                case BLASTING -> VanillaEmiRecipeCategories.BLASTING;
+                case SMOKING -> VanillaEmiRecipeCategories.SMOKING;
+                case CAMPFIRE_COOKING -> VanillaEmiRecipeCategories.CAMPFIRE_COOKING;
+                case STONECUTTING -> VanillaEmiRecipeCategories.STONECUTTING;
+                case SMITHING -> VanillaEmiRecipeCategories.SMITHING;
+                case ANVIL_REPAIRING -> VanillaEmiRecipeCategories.ANVIL_REPAIRING;
+                case GRINDING -> VanillaEmiRecipeCategories.GRINDING;
+                case BREWING -> VanillaEmiRecipeCategories.BREWING;
+                case BEACON_PAYMENT -> null;
+                case WORLD_INTERACTION_BEACON_PYRAMID, WORLD_INTERACTION_STRIPPING, WORLD_INTERACTION_SCRAPING,
+                        WORLD_INTERACTION_TILLING, WORLD_INTERACTION_FLATTENING, WORLD_INTERACTION_WAXING,
+                        WORLD_INTERACTION_OXIDIZING, WORLD_INTERACTION_DEOXIDIZING, WORLD_INTERACTION_OTHER -> VanillaEmiRecipeCategories.WORLD_INTERACTION;
+                case FUEL -> VanillaEmiRecipeCategories.FUEL;
+                case COMPOSTING -> VanillaEmiRecipeCategories.COMPOSTING;
+                case INFO -> VanillaEmiRecipeCategories.INFO;
+            }).map(category -> builtInCategories.computeIfAbsent(category, BuiltInCategory::new));
+        }
+
+        @Override
         public void addWorkstation(TlaCategory category, TlaIngredient... workstations) {
-            var emiCategory = categories.get(category);
-            if (emiCategory == null) throw new IllegalArgumentException("Category " + category + " not registered");
+            var emiCategory = getEmiCategory(category);
             for (TlaIngredient workstation : workstations) {
                 registry.addWorkstation(emiCategory, EmiUtils.convertIngredient(workstation));
             }
+        }
+
+        private EmiRecipeCategory getEmiCategory(TlaCategory category) {
+            if (category instanceof BuiltInCategory builtIn) {
+                return builtIn.category();
+            }
+            return Objects.requireNonNull(categories.get(category), "Category " + category + " not registered");
         }
 
         @Override
@@ -72,7 +112,7 @@ public class TlaApiEmiPlugin implements EmiPlugin {
                     .listAllOfType(type)
                     .forEach(recipe -> {
                         var tlaRecipe = generator.apply(recipe);
-                        var emiRecipe = new TlaEmiRecipe(tlaRecipe, categories.get(tlaRecipe.getCategory()));
+                        var emiRecipe = new TlaEmiRecipe(tlaRecipe, getEmiCategory(tlaRecipe.getCategory()));
                         registry.addRecipe(emiRecipe);
                     });
         }
@@ -80,7 +120,7 @@ public class TlaApiEmiPlugin implements EmiPlugin {
         @Override
         public void addGenerator(Function<MinecraftClient, List<TlaRecipe>> generator) {
             for (var tlaRecipe : generator.apply(MinecraftClient.getInstance())) {
-                var emiRecipe = new TlaEmiRecipe(tlaRecipe, categories.get(tlaRecipe.getCategory()));
+                var emiRecipe = new TlaEmiRecipe(tlaRecipe, getEmiCategory(tlaRecipe.getCategory()));
                 registry.addRecipe(emiRecipe);
             }
         }
@@ -168,6 +208,35 @@ public class TlaApiEmiPlugin implements EmiPlugin {
                         stack -> comparison.hashFunction().hash(EmiUtils.convertStack(stack)))
                 );
             }
+        }
+    }
+
+    private record BuiltInCategory(EmiRecipeCategory category) implements TlaCategory {
+        private static final CategoryIcon ICON = CategoryIcon.stack(TlaStack.empty());
+
+        @Override
+        public Identifier getId() {
+            return category.getId();
+        }
+
+        @Override
+        public int getDisplayHeight() {
+            return 0;
+        }
+
+        @Override
+        public int getDisplayWidth() {
+            return 0;
+        }
+
+        @Override
+        public CategoryIcon getIcon() {
+            return ICON;
+        }
+
+        @Override
+        public CategoryIcon getSimpleIcon() {
+            return ICON;
         }
     }
 }

--- a/implSrc/jei/java/io/github/mattidragon/tlaapi/impl/jei/TlaApiJeiPlugin.java
+++ b/implSrc/jei/java/io/github/mattidragon/tlaapi/impl/jei/TlaApiJeiPlugin.java
@@ -276,7 +276,7 @@ public class TlaApiJeiPlugin implements IModPlugin, PluginContext {
             case FUEL -> RecipeTypes.FUELING;
             case COMPOSTING -> RecipeTypes.COMPOSTING;
             case INFO -> RecipeTypes.INFORMATION;
-        }).map(jeiCategory -> builtInCategories.computeIfAbsent(jeiCategory.getUid(), id -> new BuiltInTlaCategory(jeiCategory, id)));
+        }).map(jeiCategory -> builtInCategories.computeIfAbsent(jeiCategory.getUid(), id -> new BuiltInTlaCategory(jeiCategory, id, type.getSize())));
     }
 
     @Override
@@ -340,7 +340,7 @@ public class TlaApiJeiPlugin implements IModPlugin, PluginContext {
     private record GhostHandler<T extends Screen>(Class<T> clazz, StackDragHandler<T> handler) {}
     private record ScreenSizeProvider<T extends Screen>(Class<T> clazz, Function<T, TlaBounds> provider) {}
     private record ExclusionZoneProvider<T extends HandledScreen<?>>(Class<T> clazz, Function<T, ? extends Iterable<TlaBounds>> provider) {}
-    private record BuiltInTlaCategory(mezz.jei.api.recipe.RecipeType<?> type, Identifier id) implements TlaCategory {
+    private record BuiltInTlaCategory(mezz.jei.api.recipe.RecipeType<?> type, Identifier id, int[] size) implements TlaCategory {
         static final CategoryIcon ICON = CategoryIcon.stack(TlaStack.empty());
 
         @Override
@@ -350,12 +350,12 @@ public class TlaApiJeiPlugin implements IModPlugin, PluginContext {
 
         @Override
         public int getDisplayHeight() {
-            return 0;
+            return size[1];
         }
 
         @Override
         public int getDisplayWidth() {
-            return 0;
+            return size[0];
         }
 
         @Override

--- a/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/TlaApiReiPlugin.java
+++ b/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/TlaApiReiPlugin.java
@@ -4,12 +4,14 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
 import dev.architectury.fluid.FluidStack;
+import io.github.mattidragon.tlaapi.api.BuiltInRecipeCategory;
 import io.github.mattidragon.tlaapi.api.StackDragHandler;
 import io.github.mattidragon.tlaapi.api.gui.TlaBounds;
 import io.github.mattidragon.tlaapi.api.plugin.Comparisons;
 import io.github.mattidragon.tlaapi.api.plugin.PluginContext;
 import io.github.mattidragon.tlaapi.api.plugin.PluginLoader;
 import io.github.mattidragon.tlaapi.api.plugin.RecipeViewer;
+import io.github.mattidragon.tlaapi.api.recipe.CategoryIcon;
 import io.github.mattidragon.tlaapi.api.recipe.TlaCategory;
 import io.github.mattidragon.tlaapi.api.recipe.TlaIngredient;
 import io.github.mattidragon.tlaapi.api.recipe.TlaRecipe;
@@ -28,6 +30,7 @@ import me.shedaniel.rei.api.client.registry.screen.SimpleClickArea;
 import me.shedaniel.rei.api.common.entry.comparison.EntryComparator;
 import me.shedaniel.rei.api.common.entry.comparison.FluidComparatorRegistry;
 import me.shedaniel.rei.api.common.entry.comparison.ItemComparatorRegistry;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.plugins.PluginManager;
 import me.shedaniel.rei.api.common.registry.ReloadStage;
 import net.minecraft.client.MinecraftClient;
@@ -42,13 +45,15 @@ import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.recipe.input.RecipeInput;
 import net.minecraft.screen.ScreenHandler;
+import net.minecraft.util.Identifier;
 
 import java.util.*;
 import java.util.function.Function;
 
 public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
+    private final Map<CategoryIdentifier<?>, BuiltInCategory> builtInCategories = new HashMap<>();
     private final Map<TlaCategory, TlaDisplayCategory> categories = new HashMap<>();
-    private final Multimap<TlaDisplayCategory, TlaIngredient> workstations = HashMultimap.create();
+    private final Multimap<TlaCategory, TlaIngredient> workstations = HashMultimap.create();
     private final List<RecipeGenerator<?>> recipeGenerators = new ArrayList<>();
     private final List<Function<MinecraftClient, List<TlaRecipe>>> customGenerators = new ArrayList<>();
     private final List<TlaDragHandler<?>> stackDragHandlers = new ArrayList<>();
@@ -94,7 +99,7 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
     @Override
     public void registerCategories(CategoryRegistry registry) {
         registry.add(Collections.unmodifiableCollection(categories.values()));
-        workstations.forEach((category, workstation) -> registry.addWorkstations(category.getCategoryIdentifier(), ReiUtil.convertIngredient(workstation)));
+        workstations.forEach((category, workstation) -> registry.addWorkstations(getCategoryIdentifier(category), ReiUtil.convertIngredient(workstation)));
     }
 
     @Override
@@ -118,7 +123,7 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
     }
 
     private TlaDisplay mapRecipe(TlaRecipe recipe) {
-        return new TlaDisplay(categories.get(recipe.getCategory()).getCategoryIdentifier(), recipe);
+        return new TlaDisplay(getCategoryIdentifier(recipe.getCategory()), recipe);
     }
 
     @Override
@@ -142,9 +147,9 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
             //noinspection unchecked
             registry.registerContainerClickArea((SimpleClickArea<HandledScreen<ScreenHandler>>) clickArea,
                     (Class<HandledScreen<ScreenHandler>>) tuple.clazz(),
-                    categories.get(tuple.category()).getCategoryIdentifier());
+                    getCategoryIdentifier(tuple.category()));
         } else {
-            registry.registerClickArea(clickArea, tuple.clazz(), categories.get(tuple.category()).getCategoryIdentifier());
+            registry.registerClickArea(clickArea, tuple.clazz(), getCategoryIdentifier(tuple.category()));
         }
     }
 
@@ -165,16 +170,51 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
 
     @Override
     public void addCategory(TlaCategory category) {
+        if (category instanceof BuiltInCategory) {
+            return;
+        }
         categories.put(category, new TlaDisplayCategory(category));
     }
 
     @Override
-    public void addWorkstation(TlaCategory category, TlaIngredient... workstations) {
-        var displayCategory = categories.get(category);
-        if (displayCategory == null) throw new IllegalArgumentException("Category " + category + " not registered");
-        for (TlaIngredient workstation : workstations) {
-            this.workstations.put(displayCategory, workstation);
+    public Optional<TlaCategory> getVanillaCategory(BuiltInRecipeCategory type) {
+        return Optional.ofNullable(switch (type) {
+            case CRAFTING -> CategoryIdentifier.of("minecraft", "plugins/crafting");
+            case SMELTING -> CategoryIdentifier.of("minecraft", "plugins/smelting");
+            case BLASTING -> CategoryIdentifier.of("minecraft", "plugins/blasting");
+            case SMOKING -> CategoryIdentifier.of("minecraft", "plugins/smoking");
+            case CAMPFIRE_COOKING -> CategoryIdentifier.of("minecraft", "plugins/campfire");
+            case STONECUTTING -> CategoryIdentifier.of("minecraft", "plugins/stone_cutting");
+            case SMITHING -> CategoryIdentifier.of("minecraft", "plugins/smithing");
+            case ANVIL_REPAIRING -> CategoryIdentifier.of("minecraft", "plugins/anvil");
+            case GRINDING -> null;//RecipeTypes.GRINDING;
+            case BREWING -> CategoryIdentifier.of("minecraft", "plugins/brewing");
+            case BEACON_PAYMENT -> CategoryIdentifier.of("minecraft", "plugins/beacon_payment");
+            case WORLD_INTERACTION_BEACON_PYRAMID -> CategoryIdentifier.of("minecraft", "plugins/beacon_base");
+            case WORLD_INTERACTION_OTHER -> null;//RecipeTypes.WORLD_INTERACTION;
+            case WORLD_INTERACTION_STRIPPING -> CategoryIdentifier.of("minecraft", "plugins/stripping");
+            case WORLD_INTERACTION_SCRAPING -> CategoryIdentifier.of("minecraft", "plugins/wax_scraping");
+            case WORLD_INTERACTION_TILLING -> CategoryIdentifier.of("minecraft", "plugins/tilling");
+            case WORLD_INTERACTION_FLATTENING -> CategoryIdentifier.of("minecraft", "plugins/pathing");
+            case WORLD_INTERACTION_WAXING -> CategoryIdentifier.of("minecraft", "plugins/waxing");
+            case WORLD_INTERACTION_OXIDIZING -> CategoryIdentifier.of("minecraft", "plugins/oxidizing");
+            case WORLD_INTERACTION_DEOXIDIZING -> CategoryIdentifier.of("minecraft", "plugins/oxidation_scraping");
+            case FUEL -> CategoryIdentifier.of("minecraft", "plugins/fuel");
+            case COMPOSTING -> CategoryIdentifier.of("minecraft", "plugins/composting");
+            case INFO -> CategoryIdentifier.of("roughlyenoughitems", "plugins/information");
+        }).map(identifier -> builtInCategories.computeIfAbsent(identifier, BuiltInCategory::new));
+    }
+
+    private CategoryIdentifier<?> getCategoryIdentifier(TlaCategory category) {
+        if (category instanceof BuiltInCategory builtIn) {
+            return builtIn.id();
         }
+        return Objects.requireNonNull(categories.get(category), "Category " + category + " not registered").getCategoryIdentifier();
+    }
+
+    @Override
+    public void addWorkstation(TlaCategory category, TlaIngredient... workstations) {
+        this.workstations.putAll(category, List.of(workstations));
     }
 
     @Override
@@ -235,6 +275,34 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
     private record Comparator<T, S>(T key, EntryComparator<S> comparator) {}
     private record RecipeGenerator<T extends Recipe<?>>(RecipeType<T> type, Function<RecipeEntry<T>, TlaRecipe> generator) {}
     private record ClickAreaTuple<T extends Screen>(Class<T> clazz, TlaCategory category, Function<T, TlaBounds> boundsFunction, boolean handledScreenCoords) {}
+    private record BuiltInCategory(CategoryIdentifier<?> id) implements TlaCategory {
+        private static final CategoryIcon ICON = CategoryIcon.stack(TlaStack.empty());
+
+        @Override
+        public Identifier getId() {
+            return id.getIdentifier();
+        }
+
+        @Override
+        public int getDisplayHeight() {
+            return 0;
+        }
+
+        @Override
+        public int getDisplayWidth() {
+            return 0;
+        }
+
+        @Override
+        public CategoryIcon getIcon() {
+            return ICON;
+        }
+
+        @Override
+        public CategoryIcon getSimpleIcon() {
+            return ICON;
+        }
+    }
 
     @SuppressWarnings("unchecked")
     private <T> T unsafeCast(Object o) {

--- a/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/TlaApiReiPlugin.java
+++ b/implSrc/rei/java/io/github/mattidragon/tlaapi/impl/rei/TlaApiReiPlugin.java
@@ -23,6 +23,7 @@ import io.github.mattidragon.tlaapi.impl.rei.util.TlaScreenSizeProvider;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.client.registry.screen.ExclusionZones;
 import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
@@ -31,6 +32,7 @@ import me.shedaniel.rei.api.common.entry.comparison.EntryComparator;
 import me.shedaniel.rei.api.common.entry.comparison.FluidComparatorRegistry;
 import me.shedaniel.rei.api.common.entry.comparison.ItemComparatorRegistry;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.plugins.PluginManager;
 import me.shedaniel.rei.api.common.registry.ReloadStage;
 import net.minecraft.client.MinecraftClient;
@@ -48,6 +50,7 @@ import net.minecraft.screen.ScreenHandler;
 import net.minecraft.util.Identifier;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
@@ -100,6 +103,9 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
     public void registerCategories(CategoryRegistry registry) {
         registry.add(Collections.unmodifiableCollection(categories.values()));
         workstations.forEach((category, workstation) -> registry.addWorkstations(getCategoryIdentifier(category), ReiUtil.convertIngredient(workstation)));
+        builtInCategories.forEach((id, category) -> {
+            category.category().set(registry.get(id).getCategory());
+        });
     }
 
     @Override
@@ -120,6 +126,13 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
                 registry.add(mapRecipe(tlaRecipe));
             }
         }
+
+        builtInCategories.forEach((id, category) -> {
+            List<? extends Display> displays = registry.get(id);
+            if (!displays.isEmpty()) {
+                category.display().set(displays.get(0));
+            }
+        });
     }
 
     private TlaDisplay mapRecipe(TlaRecipe recipe) {
@@ -202,7 +215,7 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
             case FUEL -> CategoryIdentifier.of("minecraft", "plugins/fuel");
             case COMPOSTING -> CategoryIdentifier.of("minecraft", "plugins/composting");
             case INFO -> CategoryIdentifier.of("roughlyenoughitems", "plugins/information");
-        }).map(identifier -> builtInCategories.computeIfAbsent(identifier, BuiltInCategory::new));
+        }).map(identifier -> builtInCategories.computeIfAbsent(identifier, id -> new BuiltInCategory(id, type.getSize())));
     }
 
     private CategoryIdentifier<?> getCategoryIdentifier(TlaCategory category) {
@@ -275,8 +288,17 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
     private record Comparator<T, S>(T key, EntryComparator<S> comparator) {}
     private record RecipeGenerator<T extends Recipe<?>>(RecipeType<T> type, Function<RecipeEntry<T>, TlaRecipe> generator) {}
     private record ClickAreaTuple<T extends Screen>(Class<T> clazz, TlaCategory category, Function<T, TlaBounds> boundsFunction, boolean handledScreenCoords) {}
-    private record BuiltInCategory(CategoryIdentifier<?> id) implements TlaCategory {
+    private record BuiltInCategory(
+            CategoryIdentifier<?> id,
+            int[] fallbackSize,
+            AtomicReference<DisplayCategory<?>> category,
+            AtomicReference<Display> display
+    ) implements TlaCategory {
         private static final CategoryIcon ICON = CategoryIcon.stack(TlaStack.empty());
+
+        public BuiltInCategory(CategoryIdentifier<?> id, int[] fallbackSize) {
+            this(id, fallbackSize, new AtomicReference<>(null), new AtomicReference<>(null));
+        }
 
         @Override
         public Identifier getId() {
@@ -285,12 +307,16 @@ public class TlaApiReiPlugin implements REIClientPlugin, PluginContext {
 
         @Override
         public int getDisplayHeight() {
-            return 0;
+            DisplayCategory<?> i = category.get();
+            return i == null ? fallbackSize[1] : i.getDisplayHeight();
         }
 
+        @SuppressWarnings({ "rawtypes", "unchecked" })
         @Override
         public int getDisplayWidth() {
-            return 0;
+            DisplayCategory<?> i = category.get();
+            Display d = display.get();
+            return i == null || d == null ? fallbackSize[0] : ((DisplayCategory)i).getDisplayWidth(d);
         }
 
         @Override

--- a/src/client/java/io/github/mattidragon/tlaapi/api/BuiltInRecipeCategory.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/BuiltInRecipeCategory.java
@@ -1,0 +1,47 @@
+package io.github.mattidragon.tlaapi.api;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Identifiers for the built-in recipe categories that come with the game.
+ *
+ * Use these with {@link PluginContext#getVanillaCategory} to get reference to an instance of a category in the active plugin.
+ */
+@ApiStatus.Experimental
+public enum BuiltInRecipeCategory {
+    CRAFTING,
+    SMELTING,
+    BLASTING,
+    SMOKING,
+    CAMPFIRE_COOKING,
+    STONECUTTING,
+    SMITHING,
+    ANVIL_REPAIRING,
+    GRINDING,
+    BREWING,
+    FUEL,
+    COMPOSTING,
+    INFO,
+    WORLD_INTERACTION_OTHER,
+    WORLD_INTERACTION_STRIPPING,
+    WORLD_INTERACTION_TILLING,
+    WORLD_INTERACTION_FLATTENING,
+    WORLD_INTERACTION_WAXING,
+    WORLD_INTERACTION_SCRAPING,
+    /**
+     * Only supported by REI
+     */
+    WORLD_INTERACTION_OXIDIZING,
+    /**
+     * Only supported by REI
+     */
+    WORLD_INTERACTION_DEOXIDIZING,
+    /**
+     * Only supported by REI
+     */
+    WORLD_INTERACTION_BEACON_PYRAMID,
+    /**
+     * Only supported by REI
+     */
+    BEACON_PAYMENT
+}

--- a/src/client/java/io/github/mattidragon/tlaapi/api/BuiltInRecipeCategory.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/BuiltInRecipeCategory.java
@@ -43,5 +43,25 @@ public enum BuiltInRecipeCategory {
     /**
      * Only supported by REI
      */
-    BEACON_PAYMENT
+    BEACON_PAYMENT;
+
+
+    public int[] getSize() {
+        return switch (this) {
+            case CRAFTING -> new int[] {118, 54};
+            case SMELTING, BLASTING, SMOKING, CAMPFIRE_COOKING -> new int[] {82, 38};
+            case STONECUTTING -> new int[] {76, 18};
+            case SMITHING -> new int[] {112, 18};
+            case ANVIL_REPAIRING -> new int[] {125, 18};
+            case GRINDING -> new int[] {116, 56};
+            case BREWING -> new int[] {120, 61};
+            case BEACON_PAYMENT -> new int[] {150, 140};
+            case WORLD_INTERACTION_BEACON_PYRAMID, WORLD_INTERACTION_STRIPPING, WORLD_INTERACTION_SCRAPING,
+                    WORLD_INTERACTION_TILLING, WORLD_INTERACTION_FLATTENING, WORLD_INTERACTION_WAXING,
+                    WORLD_INTERACTION_OXIDIZING, WORLD_INTERACTION_DEOXIDIZING, WORLD_INTERACTION_OTHER -> new int[] {125, 18};
+            case FUEL -> new int[] {144, 18};
+            case COMPOSTING -> new int[] {108, 18};
+            case INFO -> new int[] {144, 18};
+        };
+    }
 }

--- a/src/client/java/io/github/mattidragon/tlaapi/api/BuiltInRecipeCategory.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/BuiltInRecipeCategory.java
@@ -1,13 +1,10 @@
 package io.github.mattidragon.tlaapi.api;
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * Identifiers for the built-in recipe categories that come with the game.
  *
  * Use these with {@link PluginContext#getVanillaCategory} to get reference to an instance of a category in the active plugin.
  */
-@ApiStatus.Experimental
 public enum BuiltInRecipeCategory {
     CRAFTING,
     SMELTING,

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
@@ -1,6 +1,7 @@
 package io.github.mattidragon.tlaapi.api.plugin;
 
 import io.github.mattidragon.tlaapi.api.StackDragHandler;
+import io.github.mattidragon.tlaapi.api.BuiltInRecipeCategory;
 import io.github.mattidragon.tlaapi.api.gui.TlaBounds;
 import io.github.mattidragon.tlaapi.api.recipe.TlaCategory;
 import io.github.mattidragon.tlaapi.api.recipe.TlaIngredient;
@@ -15,9 +16,11 @@ import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.recipe.input.RecipeInput;
-
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
+
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * The main way plugins interact with the API.
@@ -33,6 +36,14 @@ public interface PluginContext {
      * @see TlaCategory
      */
     void addCategory(TlaCategory category);
+
+    /**
+     * Gets a vanilla category for a specified id
+     * @param id
+     * @see BuiltInRecipeCategory
+     */
+    @ApiStatus.Experimental
+    Optional<TlaCategory> getVanillaCategory(BuiltInRecipeCategory type);
 
     void addWorkstation(TlaCategory category, TlaIngredient... workstations);
 

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
@@ -45,6 +45,12 @@ public interface PluginContext {
     @ApiStatus.Experimental
     Optional<TlaCategory> getVanillaCategory(BuiltInRecipeCategory type);
 
+    /**
+     * Adds a block as the workstation for a recipe category.
+     *
+     * @param category The recipe category to assign to this workstation.
+     * @param workstations Ingredients matching the blocks or items that make up this workstation.
+     */
     void addWorkstation(TlaCategory category, TlaIngredient... workstations);
 
     /**

--- a/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
+++ b/src/client/java/io/github/mattidragon/tlaapi/api/plugin/PluginContext.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * The main way plugins interact with the API.
  * Provided by implementations to the plugin entrypoint.
@@ -42,7 +40,6 @@ public interface PluginContext {
      * @param id
      * @see BuiltInRecipeCategory
      */
-    @ApiStatus.Experimental
     Optional<TlaCategory> getVanillaCategory(BuiltInRecipeCategory type);
 
     /**


### PR DESCRIPTION
This has been sitting around for a few months. Sorry I didn't get to making a PR sooner as I was busy doing other things.

This adds a new `PluginContext#getVanillaCategory` method which returns an optional with a TlaCategory wrapping the original value registered by EMI/JEI/REI so mods can add their own recipes to those categories.

Example usage:
```
context.getVanillaCategory(BuiltInRecipeCategory.WORLD_INTERACTION_OTHER).ifPresent(category -> {
        context.addGenerator(client -> List.of(
            new WorldInteractionPSRecipe(category, Psychedelicraft.id("morning_glory_flowers"), 
                 TlaStack.of(PSItems.MORNING_GLORY_LATTICE).asIngredient(),
                 TlaIngredient.ofItemTag(ConventionalItemTags.SHEAR_TOOLS), TlaStack.of(PSItems.MORNING_GLORY)),
            new WorldInteractionPSRecipe(category, Psychedelicraft.id("juniper_berries"), 
                 TlaStack.of(PSItems.FRUITING_JUNIPER_LEAVES).asIngredient(),
                 TlaIngredient.ofItemTag(ConventionalItemTags.SHEAR_TOOLS), TlaStack.of(PSItems.JUNIPER_BERRIES)),
            new WorldInteractionPSRecipe(category, Psychedelicraft.id("wine_grapes"), 
                 TlaStack.of(PSItems.WINE_GRAPE_LATTICE).asIngredient(),
                 TlaIngredient.ofItemTag(ConventionalItemTags.SHEAR_TOOLS), TlaStack.of(PSItems.WINE_GRAPES))
        ));
});
```

Also on this branch is a fix for jar filename being incorrect because I got sick of constantly having to rename it. The filename now matches the format of the dependency line in the readme.